### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/aiw-devops/3c2ec108-2eb1-44a7-b58c-d696afabc0e4/aea1dbec-c1d2-4c17-a8c9-ef449188df61/_apis/work/boardbadge/cef83781-74d8-4c84-bf10-86bda2f8489a)](https://dev.azure.com/aiw-devops/3c2ec108-2eb1-44a7-b58c-d696afabc0e4/_boards/board/t/aea1dbec-c1d2-4c17-a8c9-ef449188df61/Microsoft.RequirementCategory)
 # Contoso Traders
 
 ![Logo](./docs/images/logo-1280x640.png)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#2398. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.